### PR TITLE
Rework introduction to center the space-time distinctinction

### DIFF
--- a/doc/manuscript.tex
+++ b/doc/manuscript.tex
@@ -86,33 +86,50 @@ stuff
 
 \section*{Introduction}
 
-A recent flurry of synthesis papers in high impact journals attests to surging interest in ecological forecasting. Many of the papers 
-argue that a commitment to ecological forecasting is necessary to guide the environmental policy and management
-decisions that will become increasingly critical under global change \citep{clark_ecological_2001,mouquet_review:_2015,dietze_iterative_2018}.
-A second argument is that rigorous testing of predictions will accelerate the process of basic research and discovery 
+* Forecasting is important
+* Two different approaches to this time-series & space-for-time
+	* Not clear which is best
+	* Some limited comparisons
+* Which approach is best may depend on the time-horizon
+* Here we explore this possibility using simulation based approach
+
+Forecasting is increasingly recognized as important to the advancement and application of ecological research.
+Ecological forecasting is necessary to guide the environmental policy and management
+decisions that are increasingly critical under global change \citep{clark_ecological_2001,mouquet_review:_2015,dietze_iterative_2018}.
+In addition, evaluating the accuracy of ecological forecasts can provide rigorous tests of predictions from ecological models that can
+advance understanding of the processes governing ecological systems  
 \citep{houlahan_priority_2017,dietze_prediction_2017,dietze_iterative_2018}.
-Taken together, these papers, along with a new textbook \citep{dietze_ecological_2017} represent an emerging consensus that 
-forecasting should be a priority for ecological research.
+This combined value of advancing our fundamental understanding of ecology and applying that understanding to support management and decision making 
+makes that forecasting is an important priority for ecological research.
 
-No such consensus is available for exactly how to tackle this challenge.
-Ecologists rely on many different approaches and models for making predictions, and 
-frequently argue about the virtues of process-based vs. phenomenological models (refs?).
-We often justify investments in basic research by claiming that improved process-level understanding will improve predictions (e.g.,\citealt{Adler2012}),
-and it is easy to find examples of how extrapolation of linear relationships leads to poor predictions under novel conditions \citep{Fitzpatrick,Veloz2012}.
-But in many cases simple phenomenological models make better predictions than complex process-based models with high parameter
-uncertainty (refs? \citealt{tredennick_we_2017}?).
+Ecological models used for forecasting have traditionally been based on either time-series modeling or space-for-time substitutions.
+Time-series approaches use the historical behavior of a system to fit models that describe the temporal dynamics of that system and use those
+dynamic models to make predictions about what will happen in the future. This is a common approach for population based forecasts and includes both
+process based population models and data-driven models capturing empirical patterns in data (e.g., \citep{ward_complexity_2014}) 
+Alternatively, space-for-time modeling approaches develop models of how and ecological property varies in across space in response to environmental
+conditions. These spatial relationships are assumed to also hold for changes at a site through time, and forecasts are made by forecasting future
+environmental conditions and determining the associated ecological response. Most forecasts for future species distributions and biodiversity
+are based on this type of approach, with a models built to describe the environmental conditions where species occur across space being applied to
+forecast environmental conditions to determine where they will occur in the future (e.g., citation). Despite both of these approaches being
+widely used there has been little comparison of how they compare for forecasting and understanding the dynamics of ecological systems \citep{harris_forecasting_2018}.
 
-The pragmatic solution to these debates is clear: we should forecast using the models that make the best predictions.
-Identifying these models requires rigorously testing predictions against observations. However, many common ecological predictions,
-such as a species' geographic range in the year 2100, are virtually impossible to test (but see \citealt{Maguire2015}), 
-leading \citep{dietze_iterative_2018} to call for greater emphasis on near-term forecasting. The assumption is that building 
-our capacity to make short-term forecasts will ultimately improve our long-term forecasts.
+Whether historical dynamics, contemporary spatial patterns, or a combination of the two will serve as the best source of information for forecasting
+may depend on how far into the future we are attempting to forecast \citep{harris_forecasting_2018}. This potential dependency on the "forecast horizon"; ()\textit{sensu} citation)
+results from lags in the response of ecological conditions to environmental change, changes in the importance of ecological processes with
+time scale \citep{levin_1992,rosenzweig_1995}, and differences between time-series and spatial gradients in the range of conditions present in the data.
+At short forecast horizons (days to years) conditions are likely to stay within the range of the historical data at a site, the time scales of change will be similar to
+the time scales present in that historical data, and the current state of the system is likely to capture the influence of unmeasured processes.
+As a result, for near-term forecasts time-series approaches may effectively capture the key dynamics and result in accurate forecasts. In contrast,
+at long forecast horizons (decades) an ecosystem is likely to experience conditions that have not been historically observed () and be responding to
+processes operating at scales difficult to detect in even long ecological time-series. Therefore, for the kinds of far-term forecasts typically conducted
+in biodiversity and species-distribution modeling space-for-time based approaches may include important information about how ecosystems respond to major
+shifts in climate over long periods and as a results produce better long-term forecasts. Using different approaches for different time horizons is common
+in other areas of forecasting, including forecasts for environmental conditions where models for short-term changes (weather) differ substantially from
+those for long-term changes (climate).
 
-Our goal is to consider a hypothesis that, in our view, has not been carefully considered by either the push for near-term forecasting or
-ongoing debates about competing modeling approaches. We expect that short and long-term forecasts will require models
-incorporating different kinds of processes and fit to different kinds of data sets. We demonstrate this idea using two simulation case studies, the first 
-focused on how competitive interactions affect population dynamics of a focal species, the second for  an 
-eco-evolutionary scenario. Our analyses show that: 
+Here we investigate the possibility that the best approaches for building models for ecological forecasting may depend on the time horizon of the forecast
+and explore how time-series and space-for-time approaches might be combined to address mid-term ecological forecasting. We do this using two simulation case studies, one 
+focused on how competitive interactions affect population dynamics of a focal species and one eco-evolutionary scenario. Our analyses show that: 
 \begin{enumerate}
 	\item For short-term forecasts, phenomenological time-series approaches are hard to beat, whereas longer-term forecasts require understanding slow 
 	processes such as evolutionary and ecological selection as well as dispersal.

--- a/doc/manuscript.tex
+++ b/doc/manuscript.tex
@@ -105,27 +105,30 @@ makes that forecasting is an important priority for ecological research.
 Ecological models used for forecasting have traditionally been based on either time-series modeling or space-for-time substitutions.
 Time-series approaches use the historical behavior of a system to fit models that describe the temporal dynamics of that system and use those
 dynamic models to make predictions about what will happen in the future. This is a common approach for population based forecasts and includes both
-process based population models and data-driven models capturing empirical patterns in data (e.g., \citep{ward_complexity_2014}) 
+process based population models and data-driven models capturing empirical patterns in data (e.g., \citep{ward_complexity_2014}). Time-series models
+capture processes like birth, death, small scale dispersal events, and short-term responses to environmental conditions.
 Alternatively, space-for-time modeling approaches develop models of how and ecological property varies in across space in response to environmental
 conditions. These spatial relationships are assumed to also hold for changes at a site through time, and forecasts are made by forecasting future
 environmental conditions and determining the associated ecological response. Most forecasts for future species distributions and biodiversity
 are based on this type of approach, with a models built to describe the environmental conditions where species occur across space being applied to
-forecast environmental conditions to determine where they will occur in the future (e.g., citation). Despite both of these approaches being
+forecast environmental conditions to determine where they will occur in the future (e.g., citation). Space-for-time models capture processes like
+immigration, extinction, and responses to large changes in environmental conditions over long time periods. Despite both of these approaches being
 widely used there has been little comparison of how they compare for forecasting and understanding the dynamics of ecological systems \citep{harris_forecasting_2018}.
 
 Whether historical dynamics, contemporary spatial patterns, or a combination of the two will serve as the best source of information for forecasting
 may depend on how far into the future we are attempting to forecast \citep{harris_forecasting_2018}. This potential dependency on the "forecast horizon"; ()\textit{sensu} citation)
 results from lags in the response of ecological conditions to environmental change, changes in the importance of ecological processes with
 time scale \citep{levin_1992,rosenzweig_1995}, and differences between time-series and spatial gradients in the range of conditions present in the data.
-At short forecast horizons (days to years) conditions are likely to stay within the range of the historical data at a site, the time scales of change will be similar to
-the time scales present in that historical data, and the current state of the system is likely to capture the influence of unmeasured processes.
-As a result, for near-term forecasts time-series approaches may effectively capture the key dynamics and result in accurate forecasts. In contrast,
-at long forecast horizons (decades) an ecosystem is likely to experience conditions that have not been historically observed () and be responding to
-processes operating at scales difficult to detect in even long ecological time-series. Therefore, for the kinds of far-term forecasts typically conducted
-in biodiversity and species-distribution modeling space-for-time based approaches may include important information about how ecosystems respond to major
-shifts in climate over long periods and as a results produce better long-term forecasts. Using different approaches for different time horizons is common
-in other areas of forecasting, including forecasts for environmental conditions where models for short-term changes (weather) differ substantially from
-those for long-term changes (climate).
+At short forecast horizons (days to years) processes driving individual demographics tend to dominate (similar to the time scales present in that
+historical data), conditions are likely to stay within the range of the historical data at a site, and the current state of the system is likely
+to capture the influence of unmeasured processes. As a result, for near-term forecasts time-series approaches may effectively capture the key dynamics
+and result in accurate forecasts. In contrast, at long forecast horizons (decades) an ecosystem is likely to experience conditions that have not been
+historically observed () and be responding to large scale processes large scale climate and land use change that are difficult to detect in even long
+ecological time-series. Therefore, for the kinds of long-term forecasts typically conducted in biodiversity and species-distribution modeling
+space-for-time based approaches may include important information about how ecosystems respond to major shifts in climate over long periods and as a
+results produce better long-term forecasts. Using different approaches for different time horizons is common in other areas of forecasting,
+including forecasts for environmental conditions where models for short-term changes (weather) differ substantially from those for long-term changes
+(climate).
 
 Here we investigate the possibility that the best approaches for building models for ecological forecasting may depend on the time horizon of the forecast
 and explore how time-series and space-for-time approaches might be combined to address mid-term ecological forecasting. We do this using two simulation case studies, one 

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -70,9 +70,9 @@
 	realistic projections for the coming century. Indeed, the magnitudes
 	of lags, and the relative importance of the different factors giving
 	rise to them, remain poorly understood. We review evidence for three
-	types of lag: â€œdispersal lagsâ€? affecting plant speciesâ€™ spread
-	along elevational gradients, â€œestablishment lagsâ€? following their
-	arrival in recipient communities, and â€œextinction lagsâ€? of resident
+	types of lag: â€œdispersal lagsï¿½? affecting plant speciesâ€™ spread
+	along elevational gradients, â€œestablishment lagsï¿½? following their
+	arrival in recipient communities, and â€œextinction lagsï¿½? of resident
 	species. Variation in lags is explained by variation among species
 	in physiological and demographic responses, by effects of altered
 	biotic interactions, and by aspects of the physical environment.
@@ -225,8 +225,8 @@
   pages = {201710231},
   month = jan,
   abstract = {Two foundational questions about sustainability are â€œHow are ecosystems
-	and the services they provide going to change in the future?â€? and
-	â€œHow do human decisions affect these trajectories?â€? Answering
+	and the services they provide going to change in the future?ï¿½? and
+	â€œHow do human decisions affect these trajectories?ï¿½? Answering
 	these questions requires an ability to forecast ecological processes.
 	Unfortunately, most ecological forecasts focus on centennial-scale
 	climate responses, therefore neither meeting the needs of near-term
@@ -278,7 +278,7 @@
 	extrapolation in space and time. SDMs are now widely used across
 	terrestrial, freshwater, and marine realms. Differences in methods
 	between disciplines reflect both differences in species mobility
-	and in â€œestablished use.â€? Model realism and robustness is influenced
+	and in â€œestablished use.ï¿½? Model realism and robustness is influenced
 	by selection of relevant predictors and modeling method, consideration
 	of scale, how the interplay between environmental and geographic
 	factors is handled, and the extent of extrapolation. Current linkages
@@ -341,6 +341,16 @@
   timestamp = {2019.05.24},
   url = {https://onlinelibrary.wiley.com/doi/abs/10.1111/gcb.14138},
   urldate = {2018-07-11}
+}
+
+@article{harris_forecasting_2018,
+  title={Forecasting biodiversity in breeding birds using best practices},
+  author={Harris, David J and Taylor, Shawn D and White, Ethan P},
+  journal={PeerJ},
+  volume={6},
+  pages={e4278},
+  year={2018},
+  publisher={PeerJ Inc.}
 }
 
 @ARTICLE{houlahan_priority_2017,
@@ -451,6 +461,17 @@
   year = {1992},
   volume = {2},
   pages = {397--403}
+}
+
+@article{levin_1992,
+  title={The problem of pattern and scale in ecology: the Robert H. MacArthur award lecture},
+  author={Levin, Simon A},
+  journal={Ecology},
+  volume={73},
+  number={6},
+  pages={1943--1967},
+  year={1992},
+  publisher={Wiley Online Library}
 }
 
 @ARTICLE{Maguire2015,
@@ -590,6 +611,13 @@
   urldate = {2015-06-12}
 }
 
+@book{rosenzweig_1995,
+  title={Species diversity in space and time},
+  author={Rosenzweig, Michael L and others},
+  year={1995},
+  publisher={Cambridge University Press}
+}
+
 @ARTICLE{Sala1988,
   author = {Sala, O E and Parton, W J and Joyce, L A and Lauenroth, W K},
   title = {Primary production of the central grassland region of the {United}
@@ -704,9 +732,9 @@
 
 @ARTICLE{Veloz2012,
   author = {Veloz, Samuel D and Williams, John W and Blois, Jessica L and He,
-	Feng and Ottoâ€?Bliesner, Bette and Liu, Zhengyu},
-  title = {Noâ€?analog climates and shifting realized niches during the late
-	quaternary: implications for 21stâ€?century predictions by species
+	Feng and Ottoï¿½?Bliesner, Bette and Liu, Zhengyu},
+  title = {Noï¿½?analog climates and shifting realized niches during the late
+	quaternary: implications for 21stï¿½?century predictions by species
 	distribution models},
   journal = {Global Change Biology},
   year = {2012},
@@ -746,16 +774,26 @@
 	assessing the vulnerability of species to future climate change.},
   copyright = {Â© 2011 Blackwell Publishing Ltd},
   doi = {10.1111/j.1365-2486.2011.02635.x},
-  file = {Full Text PDF:C\:\\Users\\adler\\Box\\zotero\\storage\\SHDWJG3T\\Veloz et al. - 2012 - Noâ€?analog climates and shifting realized niches du.pdf:application/pdf;Snapshot:C\:\\Users\\adler\\Box\\zotero\\storage\\8KANH4HN\\abstract.html:text/html},
+  file = {Full Text PDF:C\:\\Users\\adler\\Box\\zotero\\storage\\SHDWJG3T\\Veloz et al. - 2012 - Noï¿½?analog climates and shifting realized niches du.pdf:application/pdf;Snapshot:C\:\\Users\\adler\\Box\\zotero\\storage\\8KANH4HN\\abstract.html:text/html},
   issn = {1365-2486},
-  keywords = {climate change, hindcasting, niche shift, niche stability, noâ€?analog
-	climate, North America, paleoâ€?climate, pollen, quaternary},
+  keywords = {climate change, hindcasting, niche shift, niche stability, noï¿½?analog
+	climate, North America, paleoï¿½?climate, pollen, quaternary},
   language = {en},
   owner = {adler},
-  shorttitle = {Noâ€?analog climates and shifting realized niches during the late
+  shorttitle = {Noï¿½?analog climates and shifting realized niches during the late
 	quaternary},
   timestamp = {2019.05.24},
   url = {http://onlinelibrary.wiley.com/doi/10.1111/j.1365-2486.2011.02635.x/abstract},
   urldate = {2012-04-11}
 }
 
+@article{ward_complexity_2014,
+  title={Complexity is costly: a meta-analysis of parametric and non-parametric methods for short-term population forecasting},
+  author={Ward, Eric J and Holmes, Eli E and Thorson, James T and Collen, Ben},
+  journal={Oikos},
+  volume={123},
+  number={6},
+  pages={652--661},
+  year={2014},
+  publisher={Wiley Online Library}
+}


### PR DESCRIPTION
Since this paper focuses on time-series vs space-for-time approaches this revision
highlights both the distinction between those two approaches and the ideas behind
why the two approaches may behave differently at different time horizons.